### PR TITLE
HTTP Cache Control Middleware

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,105 @@
+package cache
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.rtnl.ai/gimlet"
+	"go.rtnl.ai/x/httpcc"
+)
+
+// If the request has an ETag header, it will be checked against the Etagger interface.
+// If the ETag matches, a 304 Not Modified response is sent. The ETag header is also
+// included in the response.
+type ETagger interface {
+	ETag() string
+}
+
+// If the request has an If-Modified-Since or If-Unmodified-Since header, it will be
+// checked against the Expirer interface using the LastModified timestamp. The Expires
+// header is also included in the response.
+type Expirer interface {
+	LastModified() time.Time
+	Expires() time.Time
+}
+
+// This interface adds the cache control directives in the response to the gin context.
+// The directives specified are then set in the response headers.
+type CacheController interface {
+	Directives() string
+}
+
+// Cache Control middleware handles cache control headers on both the request and the
+// response. If the request has a cache control header, the etag or the expiration is
+// checked and a 304 Not Modified response is sent if appropriate. Otherwise, it sets
+// the appropriate cache control headers on the response.
+//
+// NOTE: the behavior of this middleware is controlled by the interface specified above.
+// For example, if the ETagger interface is implemented, the ETag header will be checked
+// and set in the response, but if it is not implemented, the ETag header in a request
+// will be ignored.
+func Control(handler any) gin.HandlerFunc {
+	etagger, useEtag := handler.(ETagger)
+	expirer, useExpires := handler.(Expirer)
+	cc, useCC := handler.(CacheController)
+
+	return func(c *gin.Context) {
+		directives, err := httpcc.Request(c.Request)
+		if err != nil {
+			gimlet.Abort(c, http.StatusBadRequest, err)
+			return
+		}
+
+		if useEtag {
+			etag := etagger.ETag()
+			if match, ok := directives.IfNoneMatch(); ok && etag == match {
+				gimlet.Abort(c, http.StatusNotModified, nil)
+				return
+			}
+			c.Header(httpcc.ETag, etag)
+		}
+
+		if useExpires {
+			if lastModified := expirer.LastModified(); !lastModified.IsZero() {
+				if match, ok := directives.IfModifiedSince(); ok && lastModified.Before(match) {
+					gimlet.Abort(c, http.StatusNotModified, nil)
+					return
+				}
+
+				if match, ok := directives.IfUnmodifiedSince(); ok && lastModified.After(match) {
+					gimlet.Abort(c, http.StatusPreconditionFailed, nil)
+					return
+				}
+
+				c.Header(httpcc.LastModified, lastModified.UTC().Format(http.TimeFormat))
+			}
+
+			if expires := expirer.Expires(); !expires.IsZero() {
+				if expires.After(time.Now()) {
+					c.Header(httpcc.Expires, expires.UTC().Format(http.TimeFormat))
+				} else {
+					c.Header(httpcc.Expires, "0")
+				}
+			}
+		}
+
+		if useCC {
+			if directives := cc.Directives(); directives != "" {
+				c.Header(httpcc.CacheControl, directives)
+			}
+		}
+
+		gimlet.Set(c, gimlet.KeyCacheControl, directives)
+		c.Next()
+	}
+}
+
+func RequestDirectives(c *gin.Context) *httpcc.RequestDirective {
+	if val, ok := gimlet.Get(c, gimlet.KeyCacheControl); ok {
+		if directives, ok := val.(*httpcc.RequestDirective); ok {
+			return directives
+		}
+	}
+	return nil
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +16,8 @@ import (
 // included in the response.
 type ETagger interface {
 	ETag() string
+	ComputeETag([]byte)
+	SetETag(string)
 }
 
 // If the request has an If-Modified-Since or If-Unmodified-Since header, it will be
@@ -22,12 +26,15 @@ type ETagger interface {
 type Expirer interface {
 	LastModified() time.Time
 	Expires() time.Time
+	Modified(time.Time, any)
 }
 
 // This interface adds the cache control directives in the response to the gin context.
 // The directives specified are then set in the response headers.
 type CacheController interface {
 	Directives() string
+	SetMaxAge(any)
+	SetSMaxAge(any)
 }
 
 // Cache Control middleware handles cache control headers on both the request and the
@@ -52,17 +59,24 @@ func Control(handler any) gin.HandlerFunc {
 		}
 
 		if useEtag {
-			etag := etagger.ETag()
-			if match, ok := directives.IfNoneMatch(); ok && etag == match {
-				gimlet.Abort(c, http.StatusNotModified, nil)
-				return
+			if etag := etagger.ETag(); etag != "" {
+				if match, ok := directives.IfNoneMatch(); ok && etag == match {
+					gimlet.Abort(c, http.StatusNotModified, nil)
+					return
+				}
+
+				// Quote the ETag value if it's not marked as weak
+				if !strings.HasPrefix(etag, "W/") {
+					etag = strconv.Quote(etag)
+				}
+
+				c.Header(httpcc.ETag, etag)
 			}
-			c.Header(httpcc.ETag, etag)
 		}
 
 		if useExpires {
 			if lastModified := expirer.LastModified(); !lastModified.IsZero() {
-				if match, ok := directives.IfModifiedSince(); ok && lastModified.Before(match) {
+				if match, ok := directives.IfModifiedSince(); ok && (lastModified.Equal(match) || lastModified.Before(match)) {
 					gimlet.Abort(c, http.StatusNotModified, nil)
 					return
 				}
@@ -91,10 +105,12 @@ func Control(handler any) gin.HandlerFunc {
 		}
 
 		gimlet.Set(c, gimlet.KeyCacheControl, directives)
+		gimlet.Set(c, gimlet.KeyCacheHandler, handler)
 		c.Next()
 	}
 }
 
+// RequestDirectives retrieves the parsed cache control directives from the gin context.
 func RequestDirectives(c *gin.Context) *httpcc.RequestDirective {
 	if val, ok := gimlet.Get(c, gimlet.KeyCacheControl); ok {
 		if directives, ok := val.(*httpcc.RequestDirective); ok {
@@ -102,4 +118,74 @@ func RequestDirectives(c *gin.Context) *httpcc.RequestDirective {
 		}
 	}
 	return nil
+}
+
+// SetETag sets the ETag header on the handler in the gin context. If the handler does
+// not implement the ETagger interface, this function simply sets the ETag header.
+func SetETag(c *gin.Context, etag string) {
+	if val, ok := gimlet.Get(c, gimlet.KeyCacheHandler); ok {
+		if etagger, ok := val.(ETagger); ok {
+			etagger.SetETag(etag)
+		}
+	}
+	c.Header(httpcc.ETag, etag)
+}
+
+// ComputeETag computes the ETag for the data and sets it on the handler in the gin
+// as well as on the header of the response. If the handler does not implement the
+// ETagger interface, this function does nothing (not even set the header).
+func ComputeETag(c *gin.Context, data []byte) {
+	if val, ok := gimlet.Get(c, gimlet.KeyCacheHandler); ok {
+		if etagger, ok := val.(ETagger); ok {
+			etagger.ComputeETag(data)
+			c.Header(httpcc.ETag, etagger.ETag())
+		}
+	}
+}
+
+// Modified does a lot of work on the handler in the gin context. It sets the
+// Last-Modified and Expires headers based on the Expirer interface. If the handler
+// implements the CacheController interface, it will set the MaxAge directive to the
+// duration or expires timestamp as well. Note that this method will not set the
+// s-maxage directive even if the cache controller is public. That must be set in a
+// separate call.
+func Modified(c *gin.Context, lastModified time.Time, durationOrExpires any) {
+	if val, ok := gimlet.Get(c, gimlet.KeyCacheHandler); ok {
+		if expirer, ok := val.(Expirer); ok {
+			expirer.Modified(lastModified, durationOrExpires)
+
+			if lastModified := expirer.LastModified(); !lastModified.IsZero() {
+				c.Header(httpcc.LastModified, lastModified.UTC().Format(http.TimeFormat))
+			}
+
+			if expires := expirer.Expires(); !expires.IsZero() {
+				if expires.After(time.Now()) {
+					c.Header(httpcc.Expires, expires.UTC().Format(http.TimeFormat))
+				} else {
+					c.Header(httpcc.Expires, "0")
+				}
+			}
+		}
+
+		if cc, ok := val.(CacheController); ok {
+			cc.SetMaxAge(durationOrExpires)
+			if directives := cc.Directives(); directives != "" {
+				c.Header(httpcc.CacheControl, directives)
+			}
+		}
+	}
+}
+
+// SetSMaxAge sets the s-maxage directive on the handler in the gin context and on the
+// headers of the outgoing response. If the handler does not implement the
+// CacheController interface, this function does nothing.
+func SetSMaxAge(c *gin.Context, sMaxAge any) {
+	if val, ok := gimlet.Get(c, gimlet.KeyCacheHandler); ok {
+		if cc, ok := val.(CacheController); ok {
+			cc.SetSMaxAge(sMaxAge)
+			if directives := cc.Directives(); directives != "" {
+				c.Header(httpcc.CacheControl, directives)
+			}
+		}
+	}
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,7 +1,203 @@
 package cache_test
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
 
-func TestControlMiddleware(t *testing.T) {
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/gimlet/cache"
+	"go.rtnl.ai/x/httpcc"
+)
 
+func TestIntegration(t *testing.T) {
+	var mu sync.RWMutex
+	var message string
+
+	router := gin.New()
+	router.Use(cache.Control(cache.New("must-revalidate, private")))
+
+	router.GET("/", func(c *gin.Context) {
+		mu.RLock()
+		defer mu.RUnlock()
+		c.JSON(http.StatusOK, gin.H{"message": message})
+	})
+
+	router.POST("/", func(c *gin.Context) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		data := make(gin.H)
+		if err := c.BindJSON(&data); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+			return
+		}
+
+		message = data["message"].(string)
+		cache.ComputeETag(c, []byte(message))
+		cache.Modified(c, time.Now(), 20*time.Minute)
+
+		c.JSON(http.StatusOK, gin.H{"message": message})
+	})
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	t.Run("Empty", func(t *testing.T) {
+		rep, err := http.Get(srv.URL)
+		require.NoError(t, err)
+
+		defer rep.Body.Close()
+		require.Equal(t, http.StatusOK, rep.StatusCode)
+		require.Equal(t, "must-revalidate, private", rep.Header.Get("Cache-Control"))
+		require.Empty(t, rep.Header.Get("ETag"))
+		require.Empty(t, rep.Header.Get("Expires"))
+		require.Empty(t, rep.Header.Get("Last-Modified"))
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		rep, err := http.Post(srv.URL, "application/json", strings.NewReader(`{"message": "Hello, World!"}`))
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		require.Equal(t, http.StatusOK, rep.StatusCode)
+		require.Equal(t, "max-age=1200, must-revalidate, private", rep.Header.Get("Cache-Control"))
+		etag := strconv.Quote(rep.Header.Get("ETag"))
+		expires := rep.Header.Get("Expires")
+		lastModified := rep.Header.Get("Last-Modified")
+
+		rep, err = http.Get(srv.URL)
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		require.Equal(t, http.StatusOK, rep.StatusCode)
+		require.Equal(t, "max-age=1200, must-revalidate, private", rep.Header.Get("Cache-Control"))
+		require.Equal(t, etag, rep.Header.Get("ETag"))
+		require.Equal(t, expires, rep.Header.Get("Expires"))
+		require.Equal(t, lastModified, rep.Header.Get("Last-Modified"))
+	})
+
+	t.Run("IfNoneMatch", func(t *testing.T) {
+		rep, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		directives, err := httpcc.Response(rep)
+		require.NoError(t, err)
+		etag, ok := directives.ETag()
+		require.True(t, ok, "expected ETag to be present")
+
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		req.Header.Set("If-None-Match", etag)
+
+		rep, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		require.Equal(t, http.StatusNotModified, rep.StatusCode)
+	})
+
+	t.Run("IfModifiedSince", func(t *testing.T) {
+		rep, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		directives, err := httpcc.Response(rep)
+		require.NoError(t, err)
+
+		lastModified, ok := directives.LastModified()
+		require.True(t, ok, "expected Last-Modified to be present")
+
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+
+		t.Run("LastModified", func(t *testing.T) {
+			// Set If-Modified-Since to the last modified time
+			req.Header.Set(httpcc.IfModifiedSince, lastModified.Format(http.TimeFormat))
+
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// It hasn't been modified since the last modified time, so we expect a 304 Not Modified
+			require.Equal(t, http.StatusNotModified, rep.StatusCode)
+		})
+
+		t.Run("ModifiedAfter", func(t *testing.T) {
+			// Now set If-Modified-Since to a time before the last modified time
+			req.Header.Set(httpcc.IfModifiedSince, lastModified.Add(-2*time.Minute).Format(http.TimeFormat))
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// It has been modified after the if modified since time, so we expect a 200 OK
+			require.Equal(t, http.StatusOK, rep.StatusCode)
+		})
+
+		t.Run("ModifiedBefore", func(t *testing.T) {
+			// Set a time after the last modified time
+			req.Header.Set(httpcc.IfModifiedSince, lastModified.Add(2*time.Minute).Format(http.TimeFormat))
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// It hasn't been modified since the if modified since time, so we expect a 304 Not Modified
+			require.Equal(t, http.StatusNotModified, rep.StatusCode)
+		})
+	})
+
+	t.Run("IfUnmodifiedSince", func(t *testing.T) {
+		rep, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		rep.Body.Close()
+
+		directives, err := httpcc.Response(rep)
+		require.NoError(t, err)
+
+		lastModified, ok := directives.LastModified()
+		require.True(t, ok, "expected Last-Modified to be present")
+
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+
+		t.Run("LastModified", func(t *testing.T) {
+			// Set If-Unmodified-Since to the last modified time
+			req.Header.Set(httpcc.IfUnmodifiedSince, lastModified.Format(http.TimeFormat))
+
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// It has been modified after the if unmodified since time, so we expect a 200 OK
+			require.Equal(t, http.StatusOK, rep.StatusCode)
+		})
+
+		t.Run("ModifiedAfter", func(t *testing.T) {
+			// Now set If-Unmodified-Since to a time before the last modified time
+			req.Header.Set(httpcc.IfUnmodifiedSince, lastModified.Add(-2*time.Minute).Format(http.TimeFormat))
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// If it has been modified after the if unmodified since time, we expect a 412 Precondition Failed
+			require.Equal(t, http.StatusPreconditionFailed, rep.StatusCode)
+		})
+
+		t.Run("ModifiedBefore", func(t *testing.T) {
+			// Set a time after the last modified time
+			req.Header.Set(httpcc.IfUnmodifiedSince, lastModified.Add(2*time.Minute).Format(http.TimeFormat))
+			rep, err = http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			rep.Body.Close()
+
+			// It has been modified after the if modified since time, so we expect a 200 OK
+			require.Equal(t, http.StatusOK, rep.StatusCode)
+		})
+	})
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,7 @@
+package cache_test
+
+import "testing"
+
+func TestControlMiddleware(t *testing.T) {
+
+}

--- a/cache/control.go
+++ b/cache/control.go
@@ -1,0 +1,135 @@
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"go.rtnl.ai/x/httpcc"
+)
+
+// CacheControl is a thread-safe structure to manage Cache-Control headers for
+// resources and implements the CacheController interface for the cache-control
+// middleware.
+type CacheControl struct {
+	sync.RWMutex
+	builder *httpcc.ResponseBuilder
+}
+
+var _ CacheController = (*CacheControl)(nil)
+
+func (c *CacheControl) Directives() string {
+	c.RLock()
+	defer c.RUnlock()
+	if c.builder == nil {
+		return ""
+	}
+	return c.builder.String()
+}
+
+func (c *CacheControl) SetMaxAge(maxAge any) {
+	switch v := maxAge.(type) {
+	case time.Duration:
+		var seconds uint64
+		if v < 0 {
+			seconds = 0
+		} else {
+			seconds = uint64(v.Seconds())
+		}
+		c.Lock()
+		c.builder.SetMaxAge(seconds)
+		c.Unlock()
+	case uint64:
+		c.Lock()
+		c.builder.SetMaxAge(v)
+		c.Unlock()
+	case int64:
+		var seconds uint64
+		if v < 0 {
+			seconds = 0
+		} else {
+			seconds = uint64(v)
+		}
+		c.Lock()
+		c.builder.SetMaxAge(seconds)
+		c.Unlock()
+	case time.Time:
+		if v.IsZero() || v.Before(time.Now()) {
+			c.Lock()
+			c.builder.SetMaxAge(0)
+			c.Unlock()
+			return
+		}
+
+		c.Lock()
+		c.builder.SetExpires(v)
+		c.Unlock()
+	case *time.Time:
+		if v == nil || v.IsZero() || v.Before(time.Now()) {
+			c.Lock()
+			c.builder.SetMaxAge(0)
+			c.Unlock()
+			return
+		}
+
+		c.Lock()
+		c.builder.SetExpires(*v)
+		c.Unlock()
+	}
+}
+
+func (c *CacheControl) SetSMaxAge(sMaxAge any) {
+	switch v := sMaxAge.(type) {
+	case time.Duration:
+		var seconds uint64
+		if v < 0 {
+			seconds = 0
+		} else {
+			seconds = uint64(v.Seconds())
+		}
+		c.Lock()
+		c.builder.SetSMaxAge(seconds)
+		c.Unlock()
+	case uint64:
+		c.Lock()
+		c.builder.SetSMaxAge(v)
+		c.Unlock()
+	case int64:
+		var seconds uint64
+		if v < 0 {
+			seconds = 0
+		} else {
+			seconds = uint64(v)
+		}
+		c.Lock()
+		c.builder.SetSMaxAge(seconds)
+		c.Unlock()
+	case time.Time:
+		if v.IsZero() || v.Before(time.Now()) {
+			c.Lock()
+			c.builder.SetSMaxAge(0)
+			c.Unlock()
+			return
+		}
+
+		c.Lock()
+		c.builder.SetSExpires(v)
+		c.Unlock()
+	case *time.Time:
+		if v == nil || v.IsZero() || v.Before(time.Now()) {
+			c.Lock()
+			c.builder.SetSMaxAge(0)
+			c.Unlock()
+			return
+		}
+
+		c.Lock()
+		c.builder.SetSExpires(*v)
+		c.Unlock()
+	}
+}
+
+func (c *CacheControl) SetDirectives(directives httpcc.ResponseBuilder) {
+	c.Lock()
+	defer c.Unlock()
+	c.builder = &directives
+}

--- a/cache/control_test.go
+++ b/cache/control_test.go
@@ -1,0 +1,141 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/gimlet/cache"
+	"go.rtnl.ai/x/httpcc"
+)
+
+func TestCacheControl(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		ctrl := &cache.CacheControl{}
+		require.Empty(t, ctrl.Directives(), "expected empty directives")
+
+		ctrl.SetDirectives(httpcc.ResponseBuilder{})
+		require.Empty(t, ctrl.Directives(), "expected empty directives after setting empty")
+	})
+
+	t.Run("SetDirectives", func(t *testing.T) {
+		ctrl := &cache.CacheControl{}
+		directives := httpcc.ResponseBuilder{
+			Public:         true,
+			MustRevalidate: true,
+		}
+		ctrl.SetDirectives(directives)
+		require.Equal(t, "must-revalidate, public", ctrl.Directives(), "expected directives to be set")
+	})
+
+	t.Run("SetMaxAge", func(t *testing.T) {
+		ctrl := &cache.CacheControl{}
+		directives := httpcc.ResponseBuilder{
+			Private: true,
+		}
+		ctrl.SetDirectives(directives)
+
+		t.Run("Past", func(t *testing.T) {
+			testCases := []any{
+				int64(-3600),
+				-1 * time.Hour,
+				time.Duration(-10231223),
+				time.Time{},
+				time.Now().Add(-1 * time.Hour),
+				int64(0),
+				uint64(0),
+				time.Duration(0),
+				&(time.Time{}),
+				nil,
+				"",
+				true,
+				false,
+				struct{}{},
+			}
+
+			for _, tc := range testCases {
+				ctrl.SetMaxAge(tc)
+				require.Equal(t, "max-age=0, private", ctrl.Directives(), "expected max-age=0 for negative duration")
+			}
+		})
+
+		t.Run("Future", func(t *testing.T) {
+			expires := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+
+			testCases := []any{
+				int64(7199),
+				uint64(7199),
+				7199 * time.Second,
+				expires,
+				&expires,
+			}
+
+			for _, tc := range testCases {
+				ctrl.SetMaxAge(tc)
+				require.Equal(t, "max-age=7199, private", ctrl.Directives(), "expected max-age=7200 for 2 hours")
+			}
+		})
+	})
+
+	t.Run("SetSMaxAge", func(t *testing.T) {
+		ctrl := &cache.CacheControl{}
+		directives := httpcc.ResponseBuilder{
+			Public: true,
+		}
+		ctrl.SetDirectives(directives)
+
+		t.Run("Past", func(t *testing.T) {
+			testCases := []any{
+				int64(-3600),
+				-1 * time.Hour,
+				time.Duration(-10231223),
+				time.Time{},
+				time.Now().Add(-1 * time.Hour),
+				int64(0),
+				uint64(0),
+				time.Duration(0),
+				&(time.Time{}),
+				nil,
+				"",
+				true,
+				false,
+				struct{}{},
+			}
+
+			for _, tc := range testCases {
+				ctrl.SetSMaxAge(tc)
+				require.Equal(t, "s-maxage=0, public", ctrl.Directives(), "expected s-maxage=0 for negative duration")
+			}
+		})
+
+		t.Run("Future", func(t *testing.T) {
+			expires := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+
+			testCases := []any{
+				int64(7199),
+				uint64(7199),
+				7199 * time.Second,
+				expires,
+				&expires,
+			}
+			for _, tc := range testCases {
+				ctrl.SetSMaxAge(tc)
+				require.Equal(t, "s-maxage=7199, public", ctrl.Directives(), "expected s-maxage=7200 for 2 hours")
+			}
+		})
+	})
+
+	t.Run("SetExpires", func(t *testing.T) {
+		ctrl := &cache.CacheControl{}
+		directives := httpcc.ResponseBuilder{
+			Private: true,
+			Public:  true,
+		}
+		ctrl.SetDirectives(directives)
+
+		expires := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+		ctrl.SetMaxAge(expires)
+		ctrl.SetSMaxAge(expires.Add(-1 * time.Hour)) // should be ignored
+		require.Equal(t, "max-age=7199, s-maxage=3599, private, public", ctrl.Directives(), "expected expires to be set")
+	})
+}

--- a/cache/etag.go
+++ b/cache/etag.go
@@ -16,19 +16,21 @@ type ETag struct {
 	value string
 }
 
+var _ ETagger = (*ETag)(nil)
+
 func (e *ETag) ETag() string {
 	e.RLock()
 	defer e.RUnlock()
 	return e.value
 }
 
-func (e *ETag) Compute(data []byte) {
+func (e *ETag) ComputeETag(data []byte) {
 	hash := sha1.New()
 	hash.Write(data)
-	e.Set(hex.EncodeToString(hash.Sum(nil)))
+	e.SetETag(hex.EncodeToString(hash.Sum(nil)))
 }
 
-func (e *ETag) Set(value string) {
+func (e *ETag) SetETag(value string) {
 	e.Lock()
 	defer e.Unlock()
 	e.value = value
@@ -44,19 +46,21 @@ type WeakEtag struct {
 	value string
 }
 
+var _ ETagger = (*WeakEtag)(nil)
+
 func (e *WeakEtag) ETag() string {
 	e.RLock()
 	defer e.RUnlock()
 	return e.value
 }
 
-func (e *WeakEtag) Compute(data []byte) {
+func (e *WeakEtag) ComputeETag(data []byte) {
 	hash := md5.New()
 	hash.Write(data)
-	e.Set(hex.EncodeToString(hash.Sum(nil)))
+	e.SetETag(hex.EncodeToString(hash.Sum(nil)))
 }
 
-func (e *WeakEtag) Set(value string) {
+func (e *WeakEtag) SetETag(value string) {
 	value = `W/` + strconv.Quote(value)
 
 	e.Lock()

--- a/cache/etag.go
+++ b/cache/etag.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"strconv"
+	"sync"
+)
+
+// ETag is a thread-safe mechanism to compute etags for resources and implements the
+// ETagger interface for the cache-control middleware. Etags can be computed using a
+// SHA-1 hash of the resource data, or set manually.
+type ETag struct {
+	sync.RWMutex
+	value string
+}
+
+func (e *ETag) ETag() string {
+	e.RLock()
+	defer e.RUnlock()
+	return e.value
+}
+
+func (e *ETag) Compute(data []byte) {
+	hash := sha1.New()
+	hash.Write(data)
+	e.Set(hex.EncodeToString(hash.Sum(nil)))
+}
+
+func (e *ETag) Set(value string) {
+	e.Lock()
+	defer e.Unlock()
+	e.value = value
+}
+
+// WeakEtag is a thread-safe mechanism to compute weak etags for resources. It
+// implements the ETagger interface for the cache-control middleware. Weak etags are
+// similar to regular etags but are prefixed with "W/" to indicate that collisions are
+// possible. Weak etags should be used in performance critical environments. Weak etags
+// can be computed using an md5 hash of the resource data, or set manually.
+type WeakEtag struct {
+	sync.RWMutex
+	value string
+}
+
+func (e *WeakEtag) ETag() string {
+	e.RLock()
+	defer e.RUnlock()
+	return e.value
+}
+
+func (e *WeakEtag) Compute(data []byte) {
+	hash := md5.New()
+	hash.Write(data)
+	e.Set(hex.EncodeToString(hash.Sum(nil)))
+}
+
+func (e *WeakEtag) Set(value string) {
+	value = `W/` + strconv.Quote(value)
+
+	e.Lock()
+	defer e.Unlock()
+	e.value = value
+}

--- a/cache/etag_test.go
+++ b/cache/etag_test.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEtag(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		e := &ETag{}
+		require.Equal(t, "", e.ETag(), "expected empty etag")
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		e := &ETag{}
+		e.Set("test-etag")
+		require.Equal(t, `test-etag`, e.ETag(), "expected etag to be set")
+	})
+
+}

--- a/cache/etag_test.go
+++ b/cache/etag_test.go
@@ -14,8 +14,34 @@ func TestEtag(t *testing.T) {
 
 	t.Run("Set", func(t *testing.T) {
 		e := &ETag{}
-		e.Set("test-etag")
+		e.SetETag("test-etag")
 		require.Equal(t, `test-etag`, e.ETag(), "expected etag to be set")
 	})
 
+	t.Run("Compute", func(t *testing.T) {
+		e := &ETag{}
+		data := []byte("test data")
+		e.ComputeETag(data)
+		require.Equal(t, "f48dd853820860816c75d54d0f584dc863327a7c", e.ETag(), "expected etag to be computed from data")
+	})
+}
+
+func TestWeakEtag(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		e := &WeakEtag{}
+		require.Equal(t, "", e.ETag(), "expected empty weak etag")
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		e := &WeakEtag{}
+		e.SetETag("test-etag")
+		require.Equal(t, `W/"test-etag"`, e.ETag(), "expected etag to be set")
+	})
+
+	t.Run("Compute", func(t *testing.T) {
+		e := &WeakEtag{}
+		data := []byte("test data")
+		e.ComputeETag(data)
+		require.Equal(t, `W/"eb733a00c0c9d336e65691a37ab54293"`, e.ETag(), "expected etag to be computed from data")
+	})
 }

--- a/cache/expires.go
+++ b/cache/expires.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// Expires is a thread-safe mechanism to manage Last-Modified and Expires headers for
+// resources and implements the Expirer interface for the cache-control middleware.
+// The Last-Modified timestamp is set when the resource is created or updated. The
+// Expires timestamp can be computed from a max-age duration, or set manually.
+type Expires struct {
+	sync.RWMutex
+	lastModified time.Time
+	expires      time.Time
+}
+
+var _ Expirer = (*Expires)(nil)
+
+// Modified the last modified timestamp and optionally the expiration timestamp. The
+// second parameter should either be a time.Duration to compute the expiration, an
+// int64 duration in seconds, or a time.Time to set the expiration directly. If the
+// second parameter is nil, the expiration is not set.
+func (e *Expires) Modified(lastModified time.Time, durationOrExpires any) {
+	var expires time.Time
+	switch v := durationOrExpires.(type) {
+	case time.Duration:
+		expires = lastModified.Add(v)
+	case int64:
+		expires = lastModified.Add(time.Duration(v) * time.Second)
+	case time.Time:
+		expires = v
+	}
+
+	lastModified = lastModified.Truncate(time.Second).UTC()
+	expires = expires.Truncate(time.Second).UTC()
+
+	e.Lock()
+	defer e.Unlock()
+	e.lastModified = lastModified
+	e.expires = expires
+}
+
+func (e *Expires) LastModified() time.Time {
+	e.RLock()
+	defer e.RUnlock()
+	return e.lastModified
+}
+
+func (e *Expires) Expires() time.Time {
+	e.RLock()
+	defer e.RUnlock()
+	return e.expires
+}

--- a/cache/expires_test.go
+++ b/cache/expires_test.go
@@ -1,0 +1,55 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/gimlet/cache"
+)
+
+func TestExpires(t *testing.T) {
+	lastModified := time.Date(2024, 11, 21, 10, 43, 61, 0, time.UTC)
+	expires := lastModified.Add(2 * time.Hour)
+
+	t.Run("Empty", func(t *testing.T) {
+		e := &cache.Expires{}
+		require.True(t, e.LastModified().IsZero(), "expected zero last modified")
+		require.True(t, e.Expires().IsZero(), "expected zero expires")
+	})
+
+	t.Run("LastModified", func(t *testing.T) {
+		e := &cache.Expires{}
+		e.Modified(lastModified, nil)
+		require.Equal(t, lastModified, e.LastModified(), "expected last modified to be set")
+		require.True(t, e.Expires().IsZero(), "expected zero expires")
+	})
+
+	t.Run("LastModifiedBadType", func(t *testing.T) {
+		e := &cache.Expires{}
+		e.Modified(lastModified, true)
+		require.Equal(t, lastModified, e.LastModified(), "expected last modified to be set")
+		require.True(t, e.Expires().IsZero(), "expected zero expires")
+	})
+
+	t.Run("ExpiresDuration", func(t *testing.T) {
+		e := &cache.Expires{}
+		e.Modified(lastModified, 2*time.Hour)
+		require.Equal(t, lastModified, e.LastModified(), "expected last modified to be set")
+		require.Equal(t, expires, e.Expires(), "expected expires to be set from duration")
+	})
+
+	t.Run("ExpiresInt64", func(t *testing.T) {
+		e := &cache.Expires{}
+		e.Modified(lastModified, int64(7200))
+		require.Equal(t, lastModified, e.LastModified(), "expected last modified to be set")
+		require.Equal(t, expires, e.Expires(), "expected expires to be set from int64 seconds")
+	})
+
+	t.Run("ExpiresTime", func(t *testing.T) {
+		e := &cache.Expires{}
+		e.Modified(lastModified, expires)
+		require.Equal(t, lastModified, e.LastModified(), "expected last modified to be set")
+		require.Equal(t, expires, e.Expires(), "expected expires to be set from time")
+	})
+}

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1,0 +1,92 @@
+package cache
+
+import (
+	"time"
+
+	"go.rtnl.ai/x/httpcc"
+)
+
+// Manager implements the ETagger, Expirer, and CacheController interfaces for managing
+// cache control directives. It is safe for concurrent use by multiple goroutines.
+type Manager struct {
+	etag    ETag
+	expirer Expires
+	cc      CacheControl
+}
+
+// New returns a new single object cache manager with an empty response builder.
+func New(directives string) *Manager {
+	manager := &Manager{}
+	manager.SetDirectives(directives)
+	return manager
+}
+
+var _ ETagger = (*Manager)(nil)
+var _ Expirer = (*Manager)(nil)
+var _ CacheController = (*Manager)(nil)
+
+func (m *Manager) SetDirectives(directives string) {
+	if directives != "" {
+		if rep, err := httpcc.ParseResponse(directives); err == nil {
+			b := httpcc.ResponseBuilder{
+				NoCache:         rep.NoCache(),
+				NoStore:         rep.NoStore(),
+				NoTransform:     rep.NoTransform(),
+				MustRevalidate:  rep.MustRevalidate(),
+				ProxyRevalidate: rep.ProxyRevalidate(),
+				MustUnderstand:  rep.MustUnderstand(),
+				Private:         rep.Private(),
+				Public:          rep.Public(),
+				Immutable:       rep.Immutable(),
+				Extensions:      rep.Extensions(),
+			}
+
+			if maxAge, ok := rep.MaxAge(); ok {
+				b.SetMaxAge(maxAge)
+			}
+
+			if sMaxAge, ok := rep.SMaxAge(); ok {
+				b.SetSMaxAge(sMaxAge)
+			}
+
+			b.StaleWhileRevalidate, _ = rep.StaleWhileRevalidate()
+			m.cc.SetDirectives(b)
+		}
+	}
+}
+
+func (m *Manager) ETag() string {
+	return m.etag.ETag()
+}
+
+func (m *Manager) ComputeETag(data []byte) {
+	m.etag.ComputeETag(data)
+}
+
+func (m *Manager) SetETag(etag string) {
+	m.etag.SetETag(etag)
+}
+
+func (m *Manager) LastModified() time.Time {
+	return m.expirer.LastModified()
+}
+
+func (m *Manager) Expires() time.Time {
+	return m.expirer.Expires()
+}
+
+func (m *Manager) Modified(modified time.Time, durationOrExpires any) {
+	m.expirer.Modified(modified, durationOrExpires)
+	m.cc.SetMaxAge(durationOrExpires)
+}
+
+func (m *Manager) Directives() string {
+	return m.cc.Directives()
+}
+
+// SetMaxAge is a no-op for the manager; use the Modified() method to set the max age.
+func (m *Manager) SetMaxAge(maxAge any) {}
+
+func (m *Manager) SetSMaxAge(sMaxAge any) {
+	m.cc.SetSMaxAge(sMaxAge)
+}

--- a/context.go
+++ b/context.go
@@ -16,9 +16,12 @@ const (
 	KeyUserClaims
 	KeyAccessToken
 	KeyCacheControl
+	KeyCacheHandler
 )
 
-var contextKeyNames = [5]string{"unknown", "requestID", "userClaims", "accessToken", "cacheControl"}
+var contextKeyNames = [6]string{
+	"unknown", "requestID", "userClaims", "accessToken", "cacheControl", "cacheHandler",
+}
 
 func (c ContextKey) String() string {
 	if int(c) < len(contextKeyNames) {

--- a/context.go
+++ b/context.go
@@ -15,9 +15,10 @@ const (
 	KeyRequestID
 	KeyUserClaims
 	KeyAccessToken
+	KeyCacheControl
 )
 
-var contextKeyNames = [4]string{"unknown", "requestID", "userClaims", "accessToken"}
+var contextKeyNames = [5]string{"unknown", "requestID", "userClaims", "accessToken", "cacheControl"}
 
 func (c ContextKey) String() string {
 	if int(c) < len(contextKeyNames) {

--- a/context_test.go
+++ b/context_test.go
@@ -31,6 +31,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
 			{gimlet.KeyCacheControl, "public, max-age=3600"},
+			{gimlet.KeyCacheHandler, true},
 		}
 
 		for _, tc := range tests {
@@ -54,6 +55,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
 			{gimlet.KeyCacheControl, "public, max-age=3600"},
+			{gimlet.KeyCacheHandler, true},
 		}
 
 		for _, tc := range tests {
@@ -79,6 +81,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
 			{gimlet.KeyCacheControl, "public, max-age=3600"},
+			{gimlet.KeyCacheHandler, true},
 		}
 
 		for _, tc := range tests {

--- a/context_test.go
+++ b/context_test.go
@@ -30,6 +30,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyRequestID, ulid.Make()},
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
+			{gimlet.KeyCacheControl, "public, max-age=3600"},
 		}
 
 		for _, tc := range tests {
@@ -52,6 +53,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyRequestID, ulid.Make()},
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
+			{gimlet.KeyCacheControl, "public, max-age=3600"},
 		}
 
 		for _, tc := range tests {
@@ -76,6 +78,7 @@ func TestContext(t *testing.T) {
 			{gimlet.KeyRequestID, ulid.Make()},
 			{gimlet.KeyUserClaims, 42},
 			{gimlet.KeyAccessToken, "foo"},
+			{gimlet.KeyCacheControl, "public, max-age=3600"},
 		}
 
 		for _, tc := range tests {
@@ -98,6 +101,7 @@ func TestContext(t *testing.T) {
 		gimlet.Set(c, gimlet.KeyUserClaims, 42)
 		gimlet.SetContext(c, gimlet.KeyUserClaims, 24)
 		gimlet.SetContext(c, gimlet.KeyAccessToken, "foo")
+		gimlet.SetBoth(c, gimlet.KeyCacheControl, "public, max-age=3600")
 
 		// Can get a value from the gin context when it is not on the request context
 		val, exists := gimlet.Get(c, gimlet.KeyRequestID)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0
 	go.rtnl.ai/ulid v1.1.1
-	go.rtnl.ai/x v1.6.0
+	go.rtnl.ai/x v1.6.1
 	golang.org/x/time v0.12.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.rtnl.ai/ulid v1.1.1 h1:7zDInpWEeiKFcDoJyonails5lQxwOr4wc8K4TAuOVNE=
 go.rtnl.ai/ulid v1.1.1/go.mod h1:F95yPYwEEZdz5sM4GC6buziff6xD+7XVcGZ/8n37Cn0=
-go.rtnl.ai/x v1.6.0 h1:0vf35GyASdX0KND/nsLzJIRis1GrGcC7HTUFA+f7fqo=
-go.rtnl.ai/x v1.6.0/go.mod h1:aYi9mQwZPl+8ny7Hv4vs3wbghJkIeqWXwVYyG8mpqTg=
+go.rtnl.ai/x v1.6.1 h1:XWcYg7sAGd19bG29Pg8omSxjo7HLo66e/Z8dzo3gOzc=
+go.rtnl.ai/x v1.6.1/go.mod h1:aYi9mQwZPl+8ny7Hv4vs3wbghJkIeqWXwVYyG8mpqTg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/arch v0.19.0 h1:LmbDQUodHThXE+htjrnmVD73M//D9GTH6wFZjyDkjyU=


### PR DESCRIPTION
### Scope of changes

Adds Cache Control middleware to handle cache control requests and set headers on outgoing responses.

Fixes SC-33771

Depends on https://github.com/rotationalio/x/pull/27

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)

<!--
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

-->
