### PR TITLE
[FIX] Special handling for 429 + longer timeouts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,15 +23,9 @@ This PR will be merged without review.
 - [ ] I have added unit and/or integration tests that cover my changes
 - [ ] I have added new test fixtures as needed to support added tests
 - [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
+- [ ] I have documented service configuration changes or created related devops stories
 
 <!--
 - [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
 - [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
-- [ ] Documented service configuration changes or created related devops stories
-
-### Reviewer(s) checklist
-
-- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
-- [ ] Are there any TODOs in this PR that should be turned into stories?
-
 -->

--- a/auth/errors.go
+++ b/auth/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrUnknownSigningKey = errors.New("unknown signing key")
 	ErrNoKeyID           = errors.New("token does not have kid in header")
 	ErrInvalidKeyID      = errors.New("invalid key id")
+	ErrRateLimited       = errors.New("rate limited due to too many requests")
 )

--- a/auth/quarterdeck/httprc.go
+++ b/auth/quarterdeck/httprc.go
@@ -73,6 +73,11 @@ func (s *Quarterdeck) Do(req *http.Request, data interface{}) (rep *http.Respons
 			return nil, auth.ErrNotModified
 		}
 
+		// If the status code is 429 Too Many Requests, return a rate limited error message
+		if rep.StatusCode == http.StatusTooManyRequests {
+			return nil, auth.ErrRateLimited
+		}
+
 		out := make(map[string]interface{})
 		json.NewDecoder(rep.Body).Decode(&out)
 

--- a/auth/quarterdeck/options.go
+++ b/auth/quarterdeck/options.go
@@ -49,6 +49,7 @@ func WithReauthURL(reauthURL url.URL) Option {
 	}
 }
 
+// Disable running sync once during initialization.
 func NoSync() Option {
 	return func(q *Quarterdeck) error {
 		q.syncInit = false
@@ -56,6 +57,8 @@ func NoSync() Option {
 	}
 }
 
+// Disable running the sync loop upon initialization. User must call Sync and/or
+// Run manually.
 func NoRun() Option {
 	return func(q *Quarterdeck) error {
 		q.runInit = false

--- a/auth/quarterdeck/quarterdeck.go
+++ b/auth/quarterdeck/quarterdeck.go
@@ -306,16 +306,15 @@ func (s *Quarterdeck) sync() (_ bool, err error) {
 	if expires, ok := s.expires[s.configURL]; !ok || now.After(expires) {
 		var config *OpenIDConfiguration
 		if config, err = s.Config(ctx); err != nil {
-			e := fmt.Errorf("could not fetch OpenID configuration: %w", err)
 			switch {
 			case errors.Is(err, auth.ErrNotModified):
 				// Ignore 304 Not Modified errors
 			case errors.Is(err, auth.ErrRateLimited):
 				// Do not retry if we get rate limited, just try again in [SyncInterval]
-				return updated, backoff.NoRetry(e)
+				return updated, backoff.NoRetry(err)
 			default:
 				// We can retry for any other errors
-				return updated, e
+				return updated, fmt.Errorf("could not fetch OpenID configuration: %w", err)
 			}
 		}
 
@@ -350,15 +349,14 @@ func (s *Quarterdeck) sync() (_ bool, err error) {
 	if expires, ok := s.expires[s.jwksURL]; !ok || now.After(expires) {
 		var keys *jose.JSONWebKeySet
 		if keys, err = s.JWKS(ctx); err != nil {
-			e := fmt.Errorf("could not fetch JWKS: %w", err)
 			switch {
 			case errors.Is(err, auth.ErrNotModified):
 				// Ignore 304 Not Modified errors
 			case errors.Is(err, auth.ErrRateLimited):
 				// Do not retry if we get rate limited, just try again in [SyncInterval]
-				return updated, backoff.NoRetry(e)
+				return updated, backoff.NoRetry(err)
 			default:
-				return updated, e
+				return updated, fmt.Errorf("could not fetch JWKS: %w", err)
 			}
 		}
 

--- a/auth/quarterdeck/quarterdeck.go
+++ b/auth/quarterdeck/quarterdeck.go
@@ -29,7 +29,7 @@ const (
 	// Backoff settings for synchronization requests to Quarterdeck.
 	BackoffTimeout             = 5 * time.Minute
 	BackoffInitialInterval     = 5 * time.Second
-	BackoffRandomizationFactor = 0.25
+	BackoffRandomizationFactor = 0.07
 	BackoffMultiplier          = 2.0
 	BackoffMaxInterval         = 60 * time.Second
 

--- a/auth/quarterdeck/quarterdeck.go
+++ b/auth/quarterdeck/quarterdeck.go
@@ -28,10 +28,10 @@ const (
 
 	// Backoff settings for synchronization requests to Quarterdeck.
 	BackoffTimeout             = 5 * time.Minute
-	BackoffInitialInterval     = 1 * time.Second
+	BackoffInitialInterval     = 5 * time.Second
 	BackoffRandomizationFactor = 0.25
 	BackoffMultiplier          = 2.0
-	BackoffMaxInterval         = 30 * time.Second
+	BackoffMaxInterval         = 60 * time.Second
 
 	// Default interval for synchronization of JWKS and OpenID configuration if not
 	// specified by the Expires header.
@@ -282,6 +282,8 @@ func (s *Quarterdeck) Sync() (err error) {
 	return nil
 }
 
+// Performs the actual synchronization with Quarterdeck; expected to be run via
+// [backoff.Retry] in [Quarterdeck.Sync].
 func (s *Quarterdeck) sync() (_ bool, err error) {
 	s.Lock()
 	defer s.Unlock()
@@ -296,9 +298,16 @@ func (s *Quarterdeck) sync() (_ bool, err error) {
 	if expires, ok := s.expires[s.configURL]; !ok || now.After(expires) {
 		var config *OpenIDConfiguration
 		if config, err = s.Config(ctx); err != nil {
-			if !errors.Is(err, auth.ErrNotModified) {
-				// If the error is not a 304 Not Modified, return it
-				return updated, fmt.Errorf("could not fetch OpenID configuration: %w", err)
+			e := fmt.Errorf("could not fetch OpenID configuration: %w", err)
+			switch {
+			case errors.Is(err, auth.ErrNotModified):
+				// Ignore 304 Not Modified errors
+			case errors.Is(err, auth.ErrRateLimited):
+				// Do not retry if we get rate limited, just try again in [SyncInterval]
+				return updated, backoff.NoRetry(e)
+			default:
+				// We can retry for any other errors
+				return updated, e
 			}
 		}
 
@@ -333,9 +342,15 @@ func (s *Quarterdeck) sync() (_ bool, err error) {
 	if expires, ok := s.expires[s.jwksURL]; !ok || now.After(expires) {
 		var keys *jose.JSONWebKeySet
 		if keys, err = s.JWKS(ctx); err != nil {
-			if !errors.Is(err, auth.ErrNotModified) {
-				// If the error is not a 304 Not Modified, return it
-				return updated, fmt.Errorf("could not fetch JWKS: %w", err)
+			e := fmt.Errorf("could not fetch JWKS: %w", err)
+			switch {
+			case errors.Is(err, auth.ErrNotModified):
+				// Ignore 304 Not Modified errors
+			case errors.Is(err, auth.ErrRateLimited):
+				// Do not retry if we get rate limited, just try again in [SyncInterval]
+				return updated, backoff.NoRetry(e)
+			default:
+				return updated, e
 			}
 		}
 

--- a/auth/quarterdeck/quarterdeck.go
+++ b/auth/quarterdeck/quarterdeck.go
@@ -240,11 +240,19 @@ func (s *Quarterdeck) NotAuthorized(c *gin.Context) error {
 	return nil
 }
 
+// Runs the sync loop, synchronizing the JWKS and OpenID configuration from Quarterdeck,
+// and scheduling the next synchronization. Running this more than one time will
+// run more than one synchronization loop.
 func (s *Quarterdeck) Run() {
 	// Get the expiration time for the JWKS
 	wait := SyncInterval
 	if expires, ok := s.Expires(s.jwksURL); ok {
 		wait = time.Until(expires)
+		rlog.DebugAttrs(context.Background(), "jwks will expire sooner than sync interval",
+			slog.Time("expires", expires),
+			slog.Duration("wait", wait),
+			slog.Duration("syncInterval", SyncInterval),
+		)
 	}
 
 	// Synchronize then schedule the next synchronization

--- a/auth/quarterdeck/quarterdeck_test.go
+++ b/auth/quarterdeck/quarterdeck_test.go
@@ -3,6 +3,7 @@ package quarterdeck_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -68,4 +69,27 @@ func TestQuarterdeck(t *testing.T) {
 	// Should manage 304 not modified responses
 	err = qd.Sync()
 	require.NoError(t, err, "could not synchronize Quarterdeck")
+}
+
+// Ensure that rate limited responses are handled correctly: instead of hammering
+// Quarterdeck, 429 responses should circuit-break.
+func TestQuarterdeckSyncRateLimited(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	qd, err := quarterdeck.New(
+		server.URL,
+		authtest.Audience,
+		quarterdeck.NoSync(),
+		quarterdeck.NoRun(),
+	)
+	require.NoError(t, err)
+
+	err = qd.Sync()
+	require.ErrorIs(t, err, auth.ErrRateLimited, "expected rate-limit error, got %v", err)
+	require.Equal(t, int32(1), requests.Load(), "429 response should not be retried")
 }


### PR DESCRIPTION
### Scope of changes

Added special handling for when we get rate limited by quarterdeck by not retrying when we get a 429. Also extended the initial and max backoff and reduced randomness so that hopefully we will not become rate limted in the first place. Also added some comments and logging where it was clarifying.

Fixes SC-39885

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

- Test ensures no regressions
- Other tests pass

### Definition of Done

- [X] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [X] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [X] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [X] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Documented service configuration changes or created related devops stories
